### PR TITLE
Avoid listing DIRECT_TEMPLATES for which *_SAVE_AS is empty string

### DIFF
--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -250,11 +250,16 @@ class SitemapGenerator(object):
                 standard_page_save_as = self.context.get(
                     "{}_SAVE_AS".format(standard_page.upper())
                 )
+
+                # No save _SAVE_AS field means no output file. Skip.
+                if not standard_page_save_as:
+                    continue
+
                 fake = FakePage(
                     status="published",
                     date=self.now,
                     url=standard_page_url or "{}.html".format(standard_page),
-                    save_as=standard_page_save_as or "{}.html".format(standard_page),
+                    save_as=standard_page_save_as,
                 )
                 self.write_url(fake, fd)
 


### PR DESCRIPTION
From the [docs](https://docs.getpelican.com/en/stable/settings.html#url-settings):

> If you do not want one or more of the default pages to be created [...], set the corresponding *_SAVE_AS setting to '' to prevent the relevant page from being generated.