### PR TITLE
Re-factor Sitemap plugin

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: minor
+
+Re-factor plugin, including the following changes:
+
+* Act on every `content_written` signal to avoid guessing what pages to cover.
+* Instead of manually fiddling with timezones, expect `article.date` to be TZ-aware if required.
+* Add `xmlns:xhtml` to XML header.

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -200,14 +200,13 @@ class SitemapGenerator:
         fmt = config.get("format")
         if fmt not in (None, "txt", "xml"):
             log.error(
-                "sitemap: Invalid 'format' value: %r; "
-                "must be 'txt' or 'xml'", fmt,
+                "sitemap: Invalid 'format' value: %r; " "must be 'txt' or 'xml'", fmt,
             )
         exclude = config.get("exclude", ())
         if not all(isinstance(i, str) for i in exclude):
             log.error(
-                "sitemap: Invalid 'exclude' value: %r; "
-                "must be a list of str", exclude,
+                "sitemap: Invalid 'exclude' value: %r; " "must be a list of str",
+                exclude,
             )
 
 

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -6,12 +6,14 @@ Sitemap
 The sitemap plugin generates plain-text or XML sitemaps.
 """
 from datetime import datetime
-import logging as log
+import logging
 import os.path
 import re
 from urllib.request import pathname2url
 
 from pelican import contents, signals
+
+log = logging.getLogger(__name__)
 
 XML_HEADER = """<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -78,7 +78,7 @@ def content_written(path, context):
 
     def is_excluded(url, obj):
         is_private = getattr(obj, 'private', '') in ('True', 'true', '1')
-        is_hidden = not (getattr(obj, 'status', 'published') == 'published')
+        is_hidden = not getattr(obj, 'status', 'published') == 'published'
         excluded = context.get("SITEMAP", {}).get('exclude', ())
         return (is_private or is_hidden or
                 any(re.match(pattern, url) for pattern in excluded))
@@ -103,7 +103,6 @@ def content_written(path, context):
                        datetime.combine(datetime.now(), datetime.min.time()))
             content_type = {contents.Article: 'articles',
                             contents.Page: 'pages'}.get(type(obj), 'indexes')
-            print(type(obj), obj)
             changefreq = (context.get('SITEMAP', {})
                           .get('changefreqs', {})
                           .get(content_type,

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -6,7 +6,6 @@ Sitemap
 The sitemap plugin generates plain-text or XML sitemaps.
 """
 from datetime import datetime
-from itertools import filterfalse
 import logging as log
 import os.path
 import re
@@ -201,14 +200,14 @@ class SitemapGenerator:
         fmt = config.get("format")
         if fmt not in (None, "txt", "xml"):
             log.error(
-                "sitemap: Invalid 'format' value: {!r}; ",
-                "must be 'txt' or 'xml'".format(fmt),
+                "sitemap: Invalid 'format' value: %r; "
+                "must be 'txt' or 'xml'", fmt,
             )
         exclude = config.get("exclude", ())
         if not all(isinstance(i, str) for i in exclude):
             log.error(
-                "sitemap: Invalid 'exclude' value: {!r}; ",
-                "must be a list of str".format(exclude),
+                "sitemap: Invalid 'exclude' value: %r; "
+                "must be a list of str", exclude,
             )
 
 

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -5,10 +5,10 @@ Sitemap
 
 The sitemap plugin generates plain-text or XML sitemaps.
 """
-from datetime import datetime
-from logging import info, warning
 import os.path
 import re
+from datetime import datetime
+from logging import info, warning
 from urllib.request import pathname2url
 
 from pelican import contents, signals

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -17,6 +17,7 @@ from pelican import contents, signals
 XML_HEADER = """<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+xmlns:xhtml="http://www.w3.org/1999/xhtml"
 xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 """
 
@@ -26,7 +27,10 @@ XML_URL = """
 <lastmod>{2}</lastmod>
 <changefreq>{3}</changefreq>
 <priority>{4}</priority>
-</url>
+{translations}</url>
+"""
+
+XML_TRANSLATION = """<xhtml:link rel="alternate" hreflang="{}" ref="{}/{}"/>
 """
 
 XML_FOOTER = """
@@ -155,6 +159,15 @@ class SitemapGenerator:
                 )
                 changefreq = changefreqs[content_type]
                 priority = float(priorities[content_type])
+                translations = "".join(
+                    XML_TRANSLATION.format(
+                        trans.lang,
+                        siteurl,
+                        # save_as path is already output-relative
+                        clean_url(pathname2url(trans.save_as)),
+                    )
+                    for trans in getattr(obj, "translations", ())
+                )
 
                 fd.write(
                     XML_URL.format(
@@ -163,6 +176,7 @@ class SitemapGenerator:
                         lastmod,
                         changefreq,
                         priority,
+                        translations=translations,
                     )
                 )
 

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -5,45 +5,57 @@ Sitemap
 
 The sitemap plugin generates plain-text or XML sitemaps.
 """
-
-from __future__ import unicode_literals
-
-from codecs import open
-import collections
 from datetime import datetime
 from logging import info, warning
 import os.path
 import re
-
-from pytz import timezone
+from urllib.request import pathname2url
 
 from pelican import contents, signals
-from pelican.utils import get_date
 
-TXT_HEADER = """{0}/index.html
-{0}/archives.html
-{0}/tags.html
-{0}/categories.html
-"""
 
-XML_HEADER = """<?xml version="1.0" encoding="utf-8"?>
+XML_FILE_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
-xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+        xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{}
+</urlset>
 """
 
-XML_URL = """
+
+XML_URL_TEMPLATE = """
 <url>
-<loc>{0}/{1}</loc>
-<lastmod>{2}</lastmod>
-<changefreq>{3}</changefreq>
-<priority>{4}</priority>
+<loc>{loc}</loc>
+<lastmod>{lastmod}</lastmod>
+<changefreq>{changefreq}</changefreq>
+<priority>{priority}</priority>
 </url>
 """
 
-XML_FOOTER = """
-</urlset>
-"""
+
+VALID_CHANGEFREQS = (
+    "always",
+    "hourly",
+    "daily",
+    "weekly",
+    "monthly",
+    "yearly",
+    "never",
+)
+
+
+CHANGEFREQ_DEFAULTS = dict(
+    articles='monthly',
+    pages='monthly',
+    indexes='daily',
+)
+
+
+PRIORITY_DEFAULTS = dict(
+    articles=.5,
+    pages=.5,
+    indexes=.5,
+)
 
 
 def format_date(date):
@@ -55,235 +67,93 @@ def format_date(date):
     return date.strftime("%Y-%m-%dT%H:%M:%S") + tz
 
 
-class SitemapGenerator(object):
-    def __init__(self, context, settings, path, theme, output_path, *null):
-
-        self.output_path = output_path
-        self.context = context
-        self.now = datetime.now()
-        self.siteurl = settings.get("SITEURL")
-
-        self.default_timezone = settings.get("TIMEZONE", "UTC")
-        self.timezone = getattr(self, "timezone", self.default_timezone)
-        self.timezone = timezone(self.timezone)
-
-        self.format = "xml"
-
-        self.changefreqs = {
-            "articles": "monthly",
-            "indexes": "daily",
-            "pages": "monthly",
-        }
-
-        self.priorities = {"articles": 0.5, "indexes": 0.5, "pages": 0.5}
-
-        self.sitemapExclude = []
-
-        config = settings.get("SITEMAP", {})
-
-        if not isinstance(config, dict):
-            warning("sitemap plugin: the SITEMAP setting must be a dict")
-        else:
-            fmt = config.get("format")
-            pris = config.get("priorities")
-            chfreqs = config.get("changefreqs")
-            self.sitemapExclude = config.get("exclude", [])
-
-            if fmt not in ("xml", "txt"):
-                warning("sitemap plugin: SITEMAP['format'] must be `txt' or `xml'")
-                warning("sitemap plugin: Setting SITEMAP['format'] on `xml'")
-            elif fmt == "txt":
-                self.format = fmt
-                return
-
-            valid_keys = ("articles", "indexes", "pages")
-            valid_chfreqs = (
-                "always",
-                "hourly",
-                "daily",
-                "weekly",
-                "monthly",
-                "yearly",
-                "never",
-            )
-
-            if isinstance(pris, dict):
-                # We use items for Py3k compat. .iteritems() otherwise
-                for k, v in pris.items():
-                    if k in valid_keys and not isinstance(v, (int, float)):
-                        default = self.priorities[k]
-                        warning("sitemap plugin: priorities must be numbers")
-                        warning(
-                            "sitemap plugin: setting SITEMAP['priorities']"
-                            "['{0}'] on {1}".format(k, default)
-                        )
-                        pris[k] = default
-                self.priorities.update(pris)
-            elif pris is not None:
-                warning("sitemap plugin: SITEMAP['priorities'] must be a dict")
-                warning("sitemap plugin: using the default values")
-
-            if isinstance(chfreqs, dict):
-                # .items() for py3k compat.
-                for k, v in chfreqs.items():
-                    if k in valid_keys and v not in valid_chfreqs:
-                        default = self.changefreqs[k]
-                        warning("sitemap plugin: invalid changefreq `{0}'".format(v))
-                        warning(
-                            "sitemap plugin: setting SITEMAP['changefreqs']"
-                            "['{0}'] on '{1}'".format(k, default)
-                        )
-                        chfreqs[k] = default
-                self.changefreqs.update(chfreqs)
-            elif chfreqs is not None:
-                warning("sitemap plugin: SITEMAP['changefreqs'] must be a dict")
-                warning("sitemap plugin: using the default values")
-
-    def write_url(self, page, fd):  # NOQA C901
-
-        if getattr(page, "status", "published") != "published":
-            return
-
-        if getattr(page, "private", "False") == "True":
-            return
-
-        # We can disable categories/authors/etc by using False instead of ''
-        if not page.save_as:
-            return
-
-        page_path = os.path.join(self.output_path, page.save_as)
-        if not os.path.exists(page_path):
-            return
-
-        lastdate = getattr(page, "date", self.now)
-        try:
-            lastdate = self.get_date_modified(page, lastdate)
-        except ValueError:
-            warning(
-                "sitemap plugin: " + page.save_as + " has invalid modification date,"
-            )
-            warning("sitemap plugin: using date value as lastmod.")
-        lastmod = format_date(lastdate)
-
-        if isinstance(page, contents.Article):
-            pri = self.priorities["articles"]
-            chfreq = self.changefreqs["articles"]
-        elif isinstance(page, contents.Page):
-            pri = self.priorities["pages"]
-            chfreq = self.changefreqs["pages"]
-        else:
-            pri = self.priorities["indexes"]
-            chfreq = self.changefreqs["indexes"]
-
-        pageurl = "" if page.url == "index.html" else page.url
-
-        # Exclude URLs from the sitemap:
-        if self.format == "xml":
-            flag = False
-            for regstr in self.sitemapExclude:
-                if re.match(regstr, pageurl):
-                    flag = True
-                    break
-            if not flag:
-                fd.write(XML_URL.format(self.siteurl, pageurl, lastmod, chfreq, pri))
-        else:
-            fd.write(self.siteurl + "/" + pageurl + "\n")
-
-    def get_date_modified(self, page, default):
-        if hasattr(page, "modified"):
-            if isinstance(page.modified, datetime):
-                return page.modified
-            return get_date(page.modified)
-        else:
-            return default
-
-    def set_url_wrappers_modification_date(self, wrappers):
-        for (wrapper, articles) in wrappers:
-            lastmod = datetime.min.replace(tzinfo=self.timezone)
-            for article in articles:
-                lastmod = max(lastmod, article.date.replace(tzinfo=self.timezone))
-                try:
-                    modified = self.get_date_modified(article, datetime.min).replace(
-                        tzinfo=self.timezone
-                    )
-                    lastmod = max(lastmod, modified)
-                except ValueError:
-                    # Supressed: user will be notified.
-                    pass
-            setattr(wrapper, "modified", str(lastmod))
-
-    def generate_output(self, writer):
-        path = os.path.join(self.output_path, "sitemap.{0}".format(self.format))
-
-        pages = (
-            self.context["pages"]
-            + self.context["articles"]
-            + [c for (c, a) in self.context["categories"]]
-            + [t for (t, a) in self.context["tags"]]
-            + [a for (a, b) in self.context["authors"]]
-        )
-
-        self.set_url_wrappers_modification_date(self.context["categories"])
-        self.set_url_wrappers_modification_date(self.context["tags"])
-        self.set_url_wrappers_modification_date(self.context["authors"])
-
-        for article in self.context["articles"]:
-            pages += article.translations
-
-        info("writing {0}".format(path))
-
-        with open(path, "w", encoding="utf-8") as fd:
-
-            if self.format == "xml":
-                fd.write(XML_HEADER)
-            else:
-                fd.write(TXT_HEADER.format(self.siteurl))
-
-            FakePage = collections.namedtuple(
-                "FakePage", ["status", "date", "url", "save_as"]
-            )
-
-            for standard_page in self.context["DIRECT_TEMPLATES"]:
-                standard_page_url = self.context.get(
-                    "{}_URL".format(standard_page.upper())
-                )
-                standard_page_save_as = self.context.get(
-                    "{}_SAVE_AS".format(standard_page.upper())
-                )
-                fake = FakePage(
-                    status="published",
-                    date=self.now,
-                    url=standard_page_url or "{}.html".format(standard_page),
-                    save_as=standard_page_save_as or "{}.html".format(standard_page),
-                )
-                self.write_url(fake, fd)
-
-            # add template pages
-            # We use items for Py3k compat. .iteritems() otherwise
-            for path, template_page_url in self.context["TEMPLATE_PAGES"].items():
-
-                # don't add duplicate entry for index page
-                if template_page_url == "index.html":
-                    continue
-
-                fake = FakePage(
-                    status="published",
-                    date=self.now,
-                    url=template_page_url,
-                    save_as=template_page_url,
-                )
-                self.write_url(fake, fd)
-
-            for page in pages:
-                self.write_url(page, fd)
-
-            if self.format == "xml":
-                fd.write(XML_FOOTER)
+def _get_format(settings):
+    fmt = settings.get("SITEMAP", {}).get('format', 'xml')
+    assert fmt in ('txt', 'xml')
+    return fmt
 
 
-def get_generators(generators):
-    return SitemapGenerator
+def content_written(path, context):
+    rel_url = pathname2url(os.path.relpath(path, context['OUTPUT_PATH']))
+    obj = context.get('article') or context.get('page')
+
+    def is_excluded(url, obj):
+        is_private = getattr(obj, 'private', '') in ('True', 'true', '1')
+        is_hidden = not (getattr(obj, 'status', 'published') == 'published')
+        excluded = context.get("SITEMAP", {}).get('exclude', ())
+        return (is_private or is_hidden or
+                any(re.match(pattern, url) for pattern in excluded))
+
+    if is_excluded(rel_url, obj):
+        return
+
+    abs_url = context['SITEURL'] + '/' + rel_url
+    if abs_url.endswith('/index.html'):
+        abs_url = abs_url[:-len('index.html')]
+
+    fmt = _get_format(context)
+    filename = os.path.join(context['OUTPUT_PATH'], "sitemap." + fmt)
+
+    with open(filename, 'a') as file:
+        if fmt == 'txt':
+            file.write(abs_url + '\n')
+
+        elif fmt == 'xml':
+            lastmod = (getattr(obj, 'modified', None) or
+                       getattr(obj, 'date', None) or
+                       datetime.combine(datetime.now(), datetime.min.time()))
+            content_type = {contents.Article: 'articles',
+                            contents.Page: 'pages'}.get(type(obj), 'indexes')
+            print(type(obj), obj)
+            changefreq = (context.get('SITEMAP', {})
+                          .get('changefreqs', {})
+                          .get(content_type,
+                               CHANGEFREQ_DEFAULTS[content_type]))
+            assert changefreq in VALID_CHANGEFREQS
+            priority = float(context.get('SITEMAP', {})
+                             .get('priorities', {})
+                             .get(content_type,
+                                  PRIORITY_DEFAULTS[content_type]))
+            file.write(XML_URL_TEMPLATE.format(loc=abs_url,
+                                               lastmod=format_date(lastmod),
+                                               changefreq=changefreq,
+                                               priority=priority))
+
+
+def _check_config(settings):
+    config = settings.get('SITEMAP', {})
+    for key in config.keys():
+        if key not in ('format', 'exclude', 'priorities', 'changefreqs'):
+            warning("sitemap: Invalid 'SITEMAP' key: {!r}".format(key))
+    for key in config.get('changefreqs', {}).keys():
+        if key not in CHANGEFREQ_DEFAULTS:
+            warning("sitemap: Invalid 'changefreqs' key: {!r}".format(key))
+    for key in config.get('priorities', {}).keys():
+        if key not in PRIORITY_DEFAULTS:
+            warning("sitemap: Invalid 'priorities' key: {!r}".format(key))
+
+
+def initialize(pelican):
+    _check_config(pelican.settings)
+    fmt = _get_format(pelican.settings)
+    filename = os.path.join(pelican.output_path, "sitemap." + fmt)
+    with open(filename, 'w') as f:
+        f.truncate()
+
+
+def finalize(pelican):
+    fmt = _get_format(pelican.settings)
+    filename = os.path.join(pelican.output_path, "sitemap." + fmt)
+    if fmt == 'xml':
+        with open(filename, 'r+') as f:
+            contents = f.read()
+            f.seek(0)
+            f.truncate()
+            f.write(XML_FILE_TEMPLATE.format(contents))
+    info("sitemap: written {!r}".format(filename))
 
 
 def register():
-    signals.get_generators.connect(get_generators)
+    signals.content_written.connect(content_written)
+    signals.initialized.connect(initialize)
+    signals.finalized.connect(finalize)

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -108,7 +108,8 @@ class SitemapGenerator:
         fmt = config.get("format", "xml")
         is_xml = fmt == "xml"
         filename = os.path.join(output_path, "sitemap." + fmt)
-        self.page_queue.sort()
+        # Sort by paths; don't break ties to avoid error comparing Page and None
+        self.page_queue.sort(key=lambda i: i[0])
 
         def to_url(path):
             nonlocal output_path
@@ -130,7 +131,7 @@ class SitemapGenerator:
             )
 
         page_queue = [(clean_url(to_url(path)), obj) for path, obj in self.page_queue]
-        page_queue = sorted(filterfalse(is_excluded, page_queue))
+        page_queue = [page for page in page_queue if not is_excluded(page)]
 
         with open(filename, "w", encoding="utf-8") as fd:
             if is_xml:

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -5,14 +5,13 @@ Sitemap
 
 The sitemap plugin generates plain-text or XML sitemaps.
 """
-import os.path
-import re
 from datetime import datetime
 from logging import info, warning
+import os.path
+import re
 from urllib.request import pathname2url
 
 from pelican import contents, signals
-
 
 XML_FILE_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -129,11 +129,8 @@ class SitemapGenerator:
                 or any(re.match(pattern, url) for pattern in excluded)
             )
 
-        page_queue = [(to_url(path), obj) for path, obj in self.page_queue]
-        # Clean after filtering, because that was the way before, sort
-        page_queue = sorted(
-            (clean_url(url), obj) for url, obj in filterfalse(is_excluded, page_queue)
-        )
+        page_queue = [(clean_url(to_url(path)), obj) for path, obj in self.page_queue]
+        page_queue = sorted(filterfalse(is_excluded, page_queue))
 
         with open(filename, "w", encoding="utf-8") as fd:
             if is_xml:

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -43,18 +43,10 @@ VALID_CHANGEFREQS = (
 )
 
 
-CHANGEFREQ_DEFAULTS = dict(
-    articles='monthly',
-    pages='monthly',
-    indexes='daily',
-)
+CHANGEFREQ_DEFAULTS = dict(articles="monthly", pages="monthly", indexes="daily",)
 
 
-PRIORITY_DEFAULTS = dict(
-    articles=.5,
-    pages=.5,
-    indexes=.5,
-)
+PRIORITY_DEFAULTS = dict(articles=0.5, pages=0.5, indexes=0.5,)
 
 
 def format_date(date):
@@ -67,66 +59,78 @@ def format_date(date):
 
 
 def _get_format(settings):
-    fmt = settings.get("SITEMAP", {}).get('format', 'xml')
-    assert fmt in ('txt', 'xml')
+    fmt = settings.get("SITEMAP", {}).get("format", "xml")
+    assert fmt in ("txt", "xml")
     return fmt
 
 
 def content_written(path, context):
-    rel_url = pathname2url(os.path.relpath(path, context['OUTPUT_PATH']))
-    obj = context.get('article') or context.get('page')
+    rel_url = pathname2url(os.path.relpath(path, context["OUTPUT_PATH"]))
+    obj = context.get("article") or context.get("page")
 
     def is_excluded(url, obj):
-        is_private = getattr(obj, 'private', '') in ('True', 'true', '1')
-        is_hidden = not getattr(obj, 'status', 'published') == 'published'
-        excluded = context.get("SITEMAP", {}).get('exclude', ())
-        return (is_private or is_hidden or
-                any(re.match(pattern, url) for pattern in excluded))
+        is_private = getattr(obj, "private", "") in ("True", "true", "1")
+        is_hidden = not getattr(obj, "status", "published") == "published"
+        excluded = context.get("SITEMAP", {}).get("exclude", ())
+        return (
+            is_private
+            or is_hidden
+            or any(re.match(pattern, url) for pattern in excluded)
+        )
 
     if is_excluded(rel_url, obj):
         return
 
-    abs_url = context['SITEURL'] + '/' + rel_url
-    if abs_url.endswith('/index.html'):
-        abs_url = abs_url[:-len('index.html')]
+    abs_url = context["SITEURL"] + "/" + rel_url
+    if abs_url.endswith("/index.html"):
+        abs_url = abs_url[: -len("index.html")]
 
     fmt = _get_format(context)
-    filename = os.path.join(context['OUTPUT_PATH'], "sitemap." + fmt)
+    filename = os.path.join(context["OUTPUT_PATH"], "sitemap." + fmt)
 
-    with open(filename, 'a') as file:
-        if fmt == 'txt':
-            file.write(abs_url + '\n')
+    with open(filename, "a") as file:
+        if fmt == "txt":
+            file.write(abs_url + "\n")
 
-        elif fmt == 'xml':
-            lastmod = (getattr(obj, 'modified', None) or
-                       getattr(obj, 'date', None) or
-                       datetime.combine(datetime.now(), datetime.min.time()))
-            content_type = {contents.Article: 'articles',
-                            contents.Page: 'pages'}.get(type(obj), 'indexes')
-            changefreq = (context.get('SITEMAP', {})
-                          .get('changefreqs', {})
-                          .get(content_type,
-                               CHANGEFREQ_DEFAULTS[content_type]))
+        elif fmt == "xml":
+            lastmod = (
+                getattr(obj, "modified", None)
+                or getattr(obj, "date", None)
+                or datetime.combine(datetime.now(), datetime.min.time())
+            )
+            content_type = {contents.Article: "articles", contents.Page: "pages"}.get(
+                type(obj), "indexes"
+            )
+            changefreq = (
+                context.get("SITEMAP", {})
+                .get("changefreqs", {})
+                .get(content_type, CHANGEFREQ_DEFAULTS[content_type])
+            )
             assert changefreq in VALID_CHANGEFREQS
-            priority = float(context.get('SITEMAP', {})
-                             .get('priorities', {})
-                             .get(content_type,
-                                  PRIORITY_DEFAULTS[content_type]))
-            file.write(XML_URL_TEMPLATE.format(loc=abs_url,
-                                               lastmod=format_date(lastmod),
-                                               changefreq=changefreq,
-                                               priority=priority))
+            priority = float(
+                context.get("SITEMAP", {})
+                .get("priorities", {})
+                .get(content_type, PRIORITY_DEFAULTS[content_type])
+            )
+            file.write(
+                XML_URL_TEMPLATE.format(
+                    loc=abs_url,
+                    lastmod=format_date(lastmod),
+                    changefreq=changefreq,
+                    priority=priority,
+                )
+            )
 
 
 def _check_config(settings):
-    config = settings.get('SITEMAP', {})
+    config = settings.get("SITEMAP", {})
     for key in config.keys():
-        if key not in ('format', 'exclude', 'priorities', 'changefreqs'):
+        if key not in ("format", "exclude", "priorities", "changefreqs"):
             warning("sitemap: Invalid 'SITEMAP' key: {!r}".format(key))
-    for key in config.get('changefreqs', {}).keys():
+    for key in config.get("changefreqs", {}).keys():
         if key not in CHANGEFREQ_DEFAULTS:
             warning("sitemap: Invalid 'changefreqs' key: {!r}".format(key))
-    for key in config.get('priorities', {}).keys():
+    for key in config.get("priorities", {}).keys():
         if key not in PRIORITY_DEFAULTS:
             warning("sitemap: Invalid 'priorities' key: {!r}".format(key))
 
@@ -135,15 +139,15 @@ def initialize(pelican):
     _check_config(pelican.settings)
     fmt = _get_format(pelican.settings)
     filename = os.path.join(pelican.output_path, "sitemap." + fmt)
-    with open(filename, 'w') as f:
+    with open(filename, "w") as f:
         f.truncate()
 
 
 def finalize(pelican):
     fmt = _get_format(pelican.settings)
     filename = os.path.join(pelican.output_path, "sitemap." + fmt)
-    if fmt == 'xml':
-        with open(filename, 'r+') as f:
+    if fmt == "xml":
+        with open(filename, "r+") as f:
             contents = f.read()
             f.seek(0)
             f.truncate()

--- a/pelican/plugins/sitemap/test_sitemap.py
+++ b/pelican/plugins/sitemap/test_sitemap.py
@@ -1,11 +1,69 @@
 from pathlib import Path
+from shutil import rmtree
+from tempfile import mkdtemp
+import unittest
 
-from . import SitemapGenerator
+from pelican import Pelican
+from pelican.settings import read_settings
+
+from . import sitemap
 
 BASE_DIR = Path(".").resolve()
 TEST_DATA = BASE_DIR / "test_data"
 
 
-def test_sitemap_generator(tmp_path):
-    """Test the Sitemap generator."""
-    SitemapGenerator()
+class TestSitemap(unittest.TestCase):
+    def setUp(self):
+        self.output_path = mkdtemp(prefix="pelican-plugins-sitemap-tests-")
+
+    def tearDown(self):
+        rmtree(self.output_path)
+
+    def _run_pelican(self, sitemap_format):
+        settings = read_settings(
+            override={
+                "CACHE_CONTENT": False,
+                "SITEURL": "http://localhost",
+                "CONTENT": TEST_DATA,
+                "OUTPUT_PATH": self.output_path,
+
+                "PLUGINS": [sitemap],
+                "SITEMAP": {
+                    "format": sitemap_format,
+                },
+            }
+        )
+        pelican = Pelican(settings=settings)
+        pelican.run()
+
+    def test_txt(self):
+        self._run_pelican(sitemap_format="txt")
+        with open(Path(self.output_path) / "sitemap.txt") as fd:
+            contents = fd.read()
+        expected = """\
+http://localhost/
+http://localhost/archives.html
+http://localhost/authors.html
+http://localhost/categories.html
+http://localhost/category/test.html
+http://localhost/tag/bar.html
+http://localhost/tag/foo.html
+http://localhost/tag/foobar.html
+http://localhost/tags.html
+http://localhost/test-post.html
+"""
+        self.assertEqual(expected, contents)
+
+    def test_xml(self):
+        self._run_pelican(sitemap_format="xml")
+        with open(Path(self.output_path) / "sitemap.xml") as fd:
+            contents = fd.read()
+        needle = """\
+<url>
+<loc>http://localhost/test-post.html</loc>
+<lastmod>2023-07-12T13:00:00+00:00</lastmod>
+<changefreq>monthly</changefreq>
+<priority>0.5</priority>
+</url>
+"""
+        self.assertIn(needle, contents)

--- a/pelican/plugins/sitemap/test_sitemap.py
+++ b/pelican/plugins/sitemap/test_sitemap.py
@@ -13,6 +13,8 @@ TEST_DATA = BASE_DIR / "test_data"
 
 
 class TestSitemap(unittest.TestCase):
+    """Test class for Sitemap plugin."""
+
     def setUp(self):
         self.output_path = mkdtemp(prefix="pelican-plugins-sitemap-tests-")
 

--- a/pelican/plugins/sitemap/test_sitemap.py
+++ b/pelican/plugins/sitemap/test_sitemap.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-from pelican.tests.support import get_context, get_settings
-
 from . import SitemapGenerator
 
 BASE_DIR = Path(".").resolve()
@@ -10,5 +8,4 @@ TEST_DATA = BASE_DIR / "test_data"
 
 def test_sitemap_generator(tmp_path):
     """Test the Sitemap generator."""
-
-    generator = SitemapGenerator()
+    SitemapGenerator()

--- a/pelican/plugins/sitemap/test_sitemap.py
+++ b/pelican/plugins/sitemap/test_sitemap.py
@@ -26,7 +26,6 @@ class TestSitemap(unittest.TestCase):
                 "SITEURL": "http://localhost",
                 "CONTENT": TEST_DATA,
                 "OUTPUT_PATH": self.output_path,
-
                 "PLUGINS": [sitemap],
                 "SITEMAP": {
                     "format": sitemap_format,

--- a/pelican/plugins/sitemap/test_sitemap.py
+++ b/pelican/plugins/sitemap/test_sitemap.py
@@ -10,14 +10,5 @@ TEST_DATA = BASE_DIR / "test_data"
 
 def test_sitemap_generator(tmp_path):
     """Test the Sitemap generator."""
-    settings = get_settings()
-    context = get_context(settings)
-    theme = settings["THEME"]
 
-    sitemap = SitemapGenerator(context, settings, TEST_DATA, theme, tmp_path)
-
-    default_format = "xml"
-    default_priorities = {"articles": 0.5, "indexes": 0.5, "pages": 0.5}
-
-    assert sitemap.format == default_format
-    assert sitemap.priorities == default_priorities
+    generator = SitemapGenerator()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ select = [
 ignore = [
   "B010",    # `setattr` with a constant attribute value
   "D100",    # missing docstring in public module
+  "D102",    # missing docstring in public method
   "D104",    # missing docstring in public package
   "D203",    # blank line before class docstring
   "D213",    # multi-line docstring summary should start at the second line


### PR DESCRIPTION
This is an attempt at PoC simplification (ymmv) of the plugin. Comments and ideas welcome!

* Act on every `content_written` signal to avoid guessing what pages to cover.
* ~~Makes it **work correctly with i18n_subsites plugin** (before, it created a separate sitemap file for each subsite).~~ ~~Ok, this actually doesn't work. No idea what I was testing before. :cry:~~
* Don't manually fiddle with timezones. Instead, expect `article.date` to be TZ-aware if required.
* `settings['SITEURL']` is modified within `content_written` signal. With `RELATIVE_URLS=True`, the resulting advertised file locations are likely incorrect.