### PR TITLE
Remove outdated plugin configuration docs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ Here is an example configuration (it is also the default settings):
 ```python
 # Where your plug-ins reside
 PLUGIN_PATHS = ["/where/you/cloned/it/pelican-plugins/",]
-PLUGINS=["sitemap",]
+PLUGINS = ["sitemap",]
+
+# If you install it with "pip" you can specify PLUGINS as follows
+PLUGINS = ["pelican.plugins.sitemap",]
 
 SITEMAP = {
     "format": "xml",


### PR DESCRIPTION
Hi everyone,
If the plugin is installed with `pip` it should be inserted in `PLUGINS` with the value `pelican.plugins.sitemap`. I think it should be specified in the example, don't you think?

I am open to any suggestion!