### PR TITLE
Improve regex exclusion feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,15 @@ The `SITEMAP` setting must be a Python dictionary and can contain these keys:
 
     Valid frequency values are `always`, `hourly`, `daily`, `weekly`, `monthly`, `yearly` and `never`.
 
-You can exclude URLs from being included in the site map via regular expressions. For example, to exclude all URLs containing `tag/` or `category/` you can use the following `SITEMAP` setting.
+* `exclude`, which is a list of regular expressions that will be used to exclude matched URLs from the sitemap if ANY of them them match. For example:
 
 ```python
 SITEMAP = {
-    "exclude": ["tag/", "category/"]
+    "exclude": [
+        "^/noindex/",  # starts with '/noindex/'
+        "/tag/",       # contains '/tag/'
+        "\.json$",     # ends with '.json'
+    ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ The `SITEMAP` setting must be a Python dictionary and can contain these keys:
 
     Valid frequency values are `always`, `hourly`, `daily`, `weekly`, `monthly`, `yearly` and `never`.
 
-* `exclude`, which is a list of regular expressions that will be used to exclude matched URLs from the sitemap if ANY of them them match. For example:
+* `exclude`, which is a list of regular expressions that will be used to exclude matched URLs from the sitemap if *any* of them match. For example:
 
 ```python
 SITEMAP = {
     "exclude": [
-        "^/noindex/",  # starts with '/noindex/'
-        "/tag/",       # contains '/tag/'
-        "\.json$",     # ends with '.json'
+        "^/noindex/",  # starts with "/noindex/"
+        "/tag/",       # contains "/tag/"
+        "\.json$",     # ends with ".json"
     ]
 }
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+- Enable URL exclusion when using `txt` format.
+- Improve performance by compiling "exclude" regexes
+- Look for the "exclude" regexes anywhere in the URL instead of just at the start

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
 Release type: patch
 
-- Enable URL exclusion when using `txt` format.
+- Enable URL exclusion when using `txt` format
 - Improve performance by compiling "exclude" regexes
 - Look for the "exclude" regexes anywhere in the URL instead of just at the start


### PR DESCRIPTION
 - Compiles the regexes for performance
 - Fixes an oversight where exclusions weren't applied to txt-formatted sitemaps.
 - Switches to using `re.search` instead of `re.match` to match the documentation (ie. "containing" vs. "starting with") and changes the example to make it more obvious.