### PR TITLE
feat: Set ChangeFreq and Priority via metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,14 @@ SITEMAP = {
 Using Metadata
 --------------
 
-In addition to applying a configuration to all articles/pages using the `SITEMAP`, `ChangeFreq` and `Priority` can also be specified as metadata for individual articles/pages. The same restrictions on the values apply:
+In addition to applying a configuration to all articles/pages using the `SITEMAP` setting, `ChangeFreq` and `Priority` can also be specified as metadata for individual articles/pages. The same restrictions on the values apply:
+
 * Valid options for `ChangeFreq` are  `always`, `hourly`, `daily`, `weekly`, `monthly`, `yearly` and `never`.
 * Valid options for `Priority` must be a decimal number between `0` and `1`.
 
 **Example**
 
-Here is an example of using metadata in a Markdown file:
+Following is an example of using sitemap-related metadata in a Markdown file:
 
 ```
 Title: Frequently Changed Article

--- a/README.md
+++ b/README.md
@@ -81,6 +81,25 @@ SITEMAP = {
 }
 ```
 
+Using Metadata
+--------------
+
+In addition to applying a configuration to all articles/pages using the `SITEMAP`, `ChangeFreq` and `Priority` can also be specified as metadata for individual articles/pages. The same restrictions on the values apply:
+* Valid options for `ChangeFreq` are  `always`, `hourly`, `daily`, `weekly`, `monthly`, `yearly` and `never`.
+* Valid options for `Priority` must be a decimal number between `0` and `1`.
+
+**Example**
+
+Here is an example of using metadata in a Markdown file:
+
+```
+Title: Frequently Changed Article
+ChangeFreq: daily
+Priority: 0.3
+
+This is the article content.
+```
+
 Contributing
 ------------
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,0 @@
-Release type: minor
-
-Allows changefreq and priority to be set by page/article metadata

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Allows changefreq and priority to be set by page/article metadata

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -156,8 +156,23 @@ class SitemapGenerator:
                     if isinstance(obj, contents.Page)
                     else "indexes"
                 )
-                changefreq = changefreqs[content_type]
-                priority = float(priorities[content_type])
+
+                # see if changefreq specified in metadata headers, fail back to config
+                changefreq = getattr(obj, "changefreq", changefreqs[content_type])
+                if changefreq not in CHANGEFREQ_VALUES:
+                    log.error(f"sitemap: Invalid 'changefreqs' value: {changefreq!r}")
+                    changefreq = changefreqs[content_type]
+
+                # see if priority specified in metadata headers, fail back to config
+                priority_raw = getattr(obj, "priority", priorities[content_type])
+                try:
+                    priority = float(priority_raw)
+                except ValueError:
+                    log.exception(
+                        f"sitemap: Require numeric priority. Got: {priority_raw!r}"
+                    )
+                    priority = priorities[content_type]
+
                 translations = "".join(
                     XML_TRANSLATION.format(
                         trans.lang,

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -157,13 +157,13 @@ class SitemapGenerator:
                     else "indexes"
                 )
 
-                # see if changefreq specified in metadata headers, fail back to config
+                # see if changefreq specified in metadata headers; fall back to config
                 changefreq = getattr(obj, "changefreq", changefreqs[content_type])
                 if changefreq not in CHANGEFREQ_VALUES:
                     log.error(f"sitemap: Invalid 'changefreqs' value: {changefreq!r}")
                     changefreq = changefreqs[content_type]
 
-                # see if priority specified in metadata headers, fail back to config
+                # see if priority specified in metadata headers; fall back to config
                 priority_raw = getattr(obj, "priority", priorities[content_type])
                 try:
                     priority = float(priority_raw)

--- a/pelican/plugins/sitemap/test_data/article2.md
+++ b/pelican/plugins/sitemap/test_data/article2.md
@@ -1,0 +1,9 @@
+Title: Test post daily
+Date: 2023-07-12 13:00:00
+Category: test
+Tags: foo, bar, foobar
+Summary: Daily testing is my main function in life.
+ChangeFreq: daily
+Priority: 0.3
+
+This is the article content.

--- a/pelican/plugins/sitemap/test_sitemap.py
+++ b/pelican/plugins/sitemap/test_sitemap.py
@@ -51,6 +51,7 @@ http://localhost/tag/bar.html
 http://localhost/tag/foo.html
 http://localhost/tag/foobar.html
 http://localhost/tags.html
+http://localhost/test-post-daily.html
 http://localhost/test-post.html
 """
         self.assertEqual(expected, contents)
@@ -65,6 +66,16 @@ http://localhost/test-post.html
 <lastmod>2023-07-12T13:00:00+00:00</lastmod>
 <changefreq>monthly</changefreq>
 <priority>0.5</priority>
+</url>
+"""
+        self.assertIn(needle, contents)
+
+        needle = """\
+<url>
+<loc>http://localhost/test-post-daily.html</loc>
+<lastmod>2023-07-12T13:00:00+00:00</lastmod>
+<changefreq>daily</changefreq>
+<priority>0.3</priority>
 </url>
 """
         self.assertIn(needle, contents)


### PR DESCRIPTION
As suggested in #12, allows `changefreq` and `priority` to be set by article/page metadata.

* Set priority and changefreq using metadata
* Added tests for metadata
* Update README.md to reflect new feature