### PR TITLE
test: Fix sitemap test base directory.

### DIFF
--- a/pelican/plugins/sitemap/test_sitemap.py
+++ b/pelican/plugins/sitemap/test_sitemap.py
@@ -1,3 +1,4 @@
+import importlib.resources
 from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -8,7 +9,7 @@ from pelican.settings import read_settings
 
 from . import sitemap
 
-BASE_DIR = Path(__file__).parent
+BASE_DIR = importlib.resources.files(__package__)
 TEST_DATA = BASE_DIR / "test_data"
 
 

--- a/pelican/plugins/sitemap/test_sitemap.py
+++ b/pelican/plugins/sitemap/test_sitemap.py
@@ -8,7 +8,7 @@ from pelican.settings import read_settings
 
 from . import sitemap
 
-BASE_DIR = Path(".").resolve()
+BASE_DIR = Path(__file__).parent
 TEST_DATA = BASE_DIR / "test_data"
 
 
@@ -24,6 +24,7 @@ class TestSitemap(unittest.TestCase):
     def _run_pelican(self, sitemap_format):
         settings = read_settings(
             override={
+                "PATH": BASE_DIR,
                 "CACHE_CONTENT": False,
                 "SITEURL": "http://localhost",
                 "CONTENT": TEST_DATA,


### PR DESCRIPTION
When run with "pdm run invoke test", the CWD is the root of the sitemap plugin (at least on Linux). However, the test case expects to find content in the same directory as the test source file.

Closes #36.
