### PR TITLE
Support Python 3.9 through 3.13. Manage via Cruft.

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,0 +1,27 @@
+{
+  "template": "https://github.com/getpelican/cookiecutter-pelican-plugin",
+  "commit": "4e2289f3dce8517c07af48b905d557ea6500b465",
+  "checkout": null,
+  "context": {
+    "cookiecutter": {
+      "plugin_name": "Sitemap",
+      "repo_name": "sitemap",
+      "package_name": "sitemap",
+      "distribution_name": "pelican-sitemap",
+      "version": "1.1.0",
+      "description": "Pelican plugin to generate sitemap in plain-text or XML format",
+      "authors": "{name = \"Pelican Dev Team\", email = \"authors@getpelican.com\"}",
+      "keywords": "\"pelican\", \"plugin\", \"sitemap\"",
+      "readme": "README.md",
+      "contributing": "CONTRIBUTING.md",
+      "license": "GNU Affero General Public License v3|AGPL-3.0",
+      "repo_url": "https://github.com/pelican-plugins/sitemap",
+      "dev_status": "5 - Production/Stable",
+      "tests_exist": true,
+      "python_version": "~=3.9",
+      "pelican_version": ">=4.5",
+      "_template": "https://github.com/getpelican/cookiecutter-pelican-plugin"
+    }
+  },
+  "directory": null
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 env:
   PYTEST_ADDOPTS: "--color=yes"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test - Python ${{ matrix.python-version }}
@@ -63,8 +66,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -80,7 +81,7 @@ jobs:
       - name: Publish
         if: ${{ steps.check_release.outputs.autopub_release=='true' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           autopub prepare
           autopub commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 # See https://pre-commit.com/hooks.html for info on hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -21,7 +21,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.0
+    rev: v0.7.2
     hooks:
       - id: ruff
       - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Sitemap
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/pelican-plugins/sitemap/main.yml?branch=main)](https://github.com/pelican-plugins/sitemap/actions)
 [![PyPI Version](https://img.shields.io/pypi/v/pelican-sitemap)](https://pypi.org/project/pelican-sitemap/)
+[![Downloads](https://img.shields.io/pypi/dm/pelican-sitemap)](https://pypi.org/project/pelican-sitemap/)
 ![License](https://img.shields.io/pypi/l/pelican-sitemap?color=blue)
 
 This [Pelican][] plugin generates a site map in plain-text or XML format. You can use the `SITEMAP` variable in your settings file to configure the behavior of the plugin.
@@ -13,6 +14,8 @@ Installation
 This plugin can be installed via:
 
     python -m pip install pelican-sitemap
+
+As long as you have not explicitly added a `PLUGINS` setting to your Pelican settings file, then the newly-installed plugin should be automatically detected and enabled. Otherwise, you must add `sitemap` to your existing `PLUGINS` list. For more information, please see the [How to Use Plugins](https://docs.getpelican.com/en/latest/plugins.html#how-to-use-plugins) documentation.
 
 Usage
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,15 @@ classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-
-requires-python = ">=3.8.1,<4.0"
+requires-python = "~=3.9"
 dependencies = [
     "pelican>=4.5",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Framework :: Pelican",
     "Framework :: Pelican :: Plugins",
     "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+    "License :: OSI Approved :: GNU Affero General Public License v3",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
@@ -40,7 +40,7 @@ markdown = ["markdown>=3.4"]
 
 [tool.pdm.dev-dependencies]
 lint = [
-    "invoke>=2.2.0",
+    "invoke>=2.2",
     "ruff>=0.7.2,<0.8.0",
 ]
 test = [
@@ -56,7 +56,7 @@ source-includes = [
     "CONTRIBUTING.md",
 ]
 includes = ["pelican/"]
-excludes = ["tasks.py"]
+excludes = ["**/.DS_Store", "**/test_data/**", "tasks.py"]
 
 [tool.autopub]
 project-name = "Sitemap"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ markdown = ["markdown>=3.4"]
 [tool.pdm.dev-dependencies]
 lint = [
     "invoke>=2.2.0",
-    "ruff>=0.4.1,<0.5.0"
+    "ruff>=0.7.2,<0.8.0",
 ]
 test = [
     "markdown>=3.4",

--- a/tasks.py
+++ b/tasks.py
@@ -18,9 +18,10 @@ VENV = str(VENV_PATH.expanduser())
 BIN_DIR = "bin" if os.name != "nt" else "Scripts"
 VENV_BIN = Path(VENV) / Path(BIN_DIR)
 
-TOOLS = ("pdm", "pre-commit")
+TOOLS = ("cruft", "pdm", "pre-commit")
 PDM = which("pdm") if which("pdm") else (VENV_BIN / "pdm")
 CMD_PREFIX = f"{VENV_BIN}/" if ACTIVE_VENV else f"{PDM} run "
+CRUFT = which("cruft") if which("cruft") else f"{CMD_PREFIX}cruft"
 PRECOMMIT = which("pre-commit") if which("pre-commit") else f"{CMD_PREFIX}pre-commit"
 PTY = os.name != "nt"
 
@@ -79,6 +80,17 @@ def precommit(c):
     """Install pre-commit hooks to .git/hooks/pre-commit."""
     logger.info("** Installing pre-commit hooks **")
     c.run(f"{PRECOMMIT} install")
+
+
+@task
+def update(c, check=False):
+    """Apply upstream plugin template changes to this project."""
+    if check:
+        logger.info("** Checking for upstream template changes **")
+        c.run(f"{CRUFT} check", pty=PTY)
+    else:
+        logger.info("** Updating project from upstream template **")
+        c.run(f"{CRUFT} update", pty=PTY)
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -46,20 +46,22 @@ def format(c, check=False, diff=False):
 
 
 @task
-def ruff(c, fix=False, diff=False):
+def ruff(c, concise=False, fix=False, diff=False):
     """Run Ruff to ensure code meets project standards."""
-    diff_flag, fix_flag = "", ""
+    concise_flag, fix_flag, diff_flag = "", "", ""
+    if concise:
+        concise_flag = "--output-format=concise"
     if fix:
         fix_flag = "--fix"
     if diff:
         diff_flag = "--diff"
-    c.run(f"{CMD_PREFIX}ruff check {diff_flag} {fix_flag} .", pty=PTY)
+    c.run(f"{CMD_PREFIX}ruff check {concise_flag} {diff_flag} {fix_flag} .", pty=PTY)
 
 
 @task
-def lint(c, fix=False, diff=False):
+def lint(c, concise=False, fix=False, diff=False):
     """Check code style via linting tools."""
-    ruff(c, fix=fix, diff=diff)
+    ruff(c, concise=concise, fix=fix, diff=diff)
     format(c, check=(not fix), diff=diff)
 
 


### PR DESCRIPTION
This adds Cruft in order to update this plugin with changes from the upstream plugin Cookiecutter template.

This also adds Python 3.13 to the test matrix and now also requires Python 3.9+.