### PR TITLE
test: Minor clean up of settings overrides.

### DIFF
--- a/pelican/plugins/sitemap/test_sitemap.py
+++ b/pelican/plugins/sitemap/test_sitemap.py
@@ -25,10 +25,9 @@ class TestSitemap(unittest.TestCase):
     def _run_pelican(self, sitemap_format):
         settings = read_settings(
             override={
-                "PATH": BASE_DIR,
+                "PATH": TEST_DATA,
                 "CACHE_CONTENT": False,
                 "SITEURL": "http://localhost",
-                "CONTENT": TEST_DATA,
                 "OUTPUT_PATH": self.output_path,
                 "PLUGINS": [sitemap],
                 "SITEMAP": {


### PR DESCRIPTION
Follow-up to 3186431, as per comment here: https://github.com/pelican-plugins/sitemap/pull/37#discussion_r1828499026

- `CONTENT` key is unused
- `PATH` key determines the content path