### PR TITLE
Integrate upstream plugin template changes

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/getpelican/cookiecutter-pelican-plugin",
-  "commit": "4e2289f3dce8517c07af48b905d557ea6500b465",
+  "commit": "21ae5f20cc2dceebd39f838458ce60f77f9e6743",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -20,7 +20,8 @@
       "tests_exist": true,
       "python_version": "~=3.9",
       "pelican_version": ">=4.5",
-      "_template": "https://github.com/getpelican/cookiecutter-pelican-plugin"
+      "_template": "https://github.com/getpelican/cookiecutter-pelican-plugin",
+      "_commit": "21ae5f20cc2dceebd39f838458ce60f77f9e6743"
     }
   },
   "directory": null

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,11 +41,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate links in Markdown files
-        uses: JustinBeckwith/linkinator-action@v1
-        with:
-          retry: true
-
       - name: Set up Python & PDM
         uses: pdm-project/setup-pdm@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }} & PDM
         uses: pdm-project/setup-pdm@v4
@@ -36,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Validate links in Markdown files
         uses: JustinBeckwith/linkinator-action@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.11.13
     hooks:
       - id: ruff
       - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ To start contributing to this plugin, review the [Contributing to Pelican][] doc
 License
 -------
 
-This project is licensed under the [AGPL-3.0](http://www.gnu.org/licenses/agpl-3.0-standalone.html) license.
+This project is licensed under the [AGPL-3.0](https://www.gnu.org/licenses/agpl-3.0-standalone.html) license.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+- test: Clean up settings overrides
+- chore: Remove Blinker pin after fixed 1.9 release
+- docs: Priority must be specified as floating point

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,21 +29,21 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/pelican-plugins/sitemap"
+"Homepage" = "https://github.com/pelican-plugins/sitemap"
 "Issue Tracker" = "https://github.com/pelican-plugins/sitemap/issues"
-Funding = "https://donate.getpelican.com/"
+"Changelog" = "https://github.com/pelican-plugins/sitemap/blob/main/CHANGELOG.md"
+"Funding" = "https://donate.getpelican.com/"
 
 [project.optional-dependencies]
 markdown = ["markdown>=3.4"]
 
-[tool.pdm]
-
-[tool.pdm.dev-dependencies]
+[dependency-groups]
 lint = [
     "invoke>=2.2",
-    "ruff>=0.7.2,<0.8.0",
+    "ruff>=0.11.0,<1.0.0",
 ]
 test = [
+    "invoke>=2.2",
     "markdown>=3.4",
     "pytest>=7.0",
     "pytest-cov>=4.0",


### PR DESCRIPTION
- **Integrate upstream plugin template changes**
- **Fix URL link to AGPL license**
- **Remove Linkinator action**

Regarding the last item, Linkinator is causing CI to fail because it thinks the AGPL link in the README is broken, even though it loads just fine in a browser.

Maybe Gnu.org is throttling/blocking GitHub, but regardless of the reason, I get the impression the Linkinator action has outlived its usefulness and should be removed.
