### PR TITLE
feat: support i18n_subsites and fix sitemap format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .pdm-python
 pdm.lock
+
+__pycache__/

--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -3,7 +3,9 @@
 from datetime import datetime
 import logging
 import os.path
+import posixpath
 import re
+from urllib.parse import urlparse, urlunparse
 from urllib.request import pathname2url
 
 from pelican import contents, signals
@@ -17,19 +19,17 @@ xmlns:xhtml="http://www.w3.org/1999/xhtml"
 xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 """
 
-TXT_URL = "{0}/{1}\n"
+TXT_URL = "{0}\n"
 
-XML_URL = """
-<url>
-<loc>{0}/{1}</loc>
-<lastmod>{2}</lastmod>
-<changefreq>{3}</changefreq>
-<priority>{4}</priority>
-{translations}</url>
+XML_URL = """<url>
+<loc>{0}</loc>
+<lastmod>{1}</lastmod>
+<changefreq>{2}</changefreq>
+<priority>{3}</priority>
+{4}</url>
 """
 
-XML_TRANSLATION = """<xhtml:link rel="alternate" hreflang="{}" ref="{}/{}"/>
-"""
+XML_TRANSLATION = """<xhtml:link rel="alternate" hreflang="{0}" href="{1}"/>"""
 
 XML_FOOTER = """
 </urlset>
@@ -75,17 +75,24 @@ class SitemapGenerator:
         self.now = datetime.now()
         self.page_queue = []
         self._main_pelican = None
+        self._main_siteurl = None
+        self._main_lang = None
 
     def init(self, pelican):
         """Initialize the plugin."""
         log.debug("sitemap: Initialize")
         if self._main_pelican is None:
             self._main_pelican = pelican
+            self._main_siteurl = pelican.settings.get("SITEURL", "")
+            self._main_lang = pelican.settings.get("DEFAULT_LANG", "en")
 
     def queue_page(self, path, context):
         """Queue one site page for later generation."""
         obj = context.get("article") or context.get("page")
-        self.page_queue.append((path, obj))
+        # Store the current language context along with the page
+        current_lang = context.get("DEFAULT_LANG", self._main_lang)
+        current_siteurl = context.get("SITEURL", self._main_siteurl)
+        self.page_queue.append((path, obj, current_lang, current_siteurl))
 
     def finalize(self, pelican):
         """Write the sitemap of queued pages."""
@@ -95,6 +102,8 @@ class SitemapGenerator:
             self._write_out(pelican)
             # Reset for autoreload
             self._main_pelican = None
+            self._main_siteurl = None
+            self._main_lang = None
             self.page_queue = []
 
     def _write_out(self, pelican):
@@ -119,9 +128,8 @@ class SitemapGenerator:
             # Strip trailing 'index.html'
             return re.sub(r"(?:^|(?<=/))index.html$", "", url)
 
-        def is_excluded(item):
+        def is_excluded(url, obj):
             nonlocal excluded
-            url, obj = item
             is_private = getattr(obj, "private", "") == "True"
             is_hidden = getattr(obj, "status", "published") != "published"
             return (
@@ -130,25 +138,93 @@ class SitemapGenerator:
                 or any(re.search(pattern, url) for pattern in excluded)
             )
 
-        # Use obj.url for articles/pages to respect custom URL settings
-        # (e.g., ARTICLE_URL). Fall back to to_url(path) for index pages
-        # (archives, tags, etc.) which don't have a .url property as they're
-        # not Article or Page objects.
-        page_queue = [
-            (clean_url(obj.url if obj else to_url(path)), obj)
-            for path, obj in self.page_queue
-        ]
-        page_queue = [page for page in page_queue if not is_excluded(page)]
-        page_queue.sort(key=lambda i: i[0])
+        def get_full_url(page_siteurl, page_url, is_index=False):
+            """Build full URL and normalize any ../ segments."""
+            if page_url.startswith("http"):
+                return page_url
+            base = siteurl if is_index else page_siteurl
+            full = "{0}/{1}".format(base.rstrip("/"), page_url.lstrip("/"))
+            # Normalize path using posixpath (handles ../ segments)
+            parsed = urlparse(full)
+            normalized = posixpath.normpath(parsed.path)
+            # Restore trailing slash if original had one
+            if parsed.path.endswith("/") and not normalized.endswith("/"):
+                normalized += "/"
+            return urlunparse(parsed._replace(path=normalized))
+
+        def add_to_url_map(url_map, slug_translations, path, obj, lang, page_siteurl):
+            """Add a page to the URL map and track slug translations."""
+            if obj is None:
+                # Index pages - no translations
+                page_url = clean_url(to_url(path))
+                if any(re.search(pattern, page_url) for pattern in excluded):
+                    return
+                full_url = get_full_url(page_siteurl, page_url, is_index=True)
+                if full_url not in url_map:
+                    url_map[full_url] = {"obj": None, "slug": None, "translations": {}}
+                return
+
+            # Articles and pages
+            page_url = clean_url(obj.url)
+            if is_excluded(page_url, obj):
+                return
+            full_url = get_full_url(page_siteurl, page_url)
+            slug = getattr(obj, "slug", None)
+            obj_lang = getattr(obj, "lang", lang)
+            if full_url not in url_map:
+                url_map[full_url] = {"obj": obj, "slug": slug, "translations": {}}
+            # Group by slug for i18n_subsites
+            if slug:
+                slug_translations.setdefault(slug, {})[obj_lang] = full_url
+
+        def link_translations(url_map, slug_translations):
+            """Link translations to each URL entry."""
+            for full_url, data in url_map.items():
+                obj = data["obj"]
+                slug = data["slug"]
+                translations = {}
+                # Add translations from slug grouping (i18n_subsites)
+                if slug in slug_translations:
+                    translations.update(slug_translations[slug])
+                # Add translations from Pelican's native translation mechanism
+                if obj is not None:
+                    obj_lang = getattr(obj, "lang", None)
+                    if obj_lang:
+                        translations[obj_lang] = full_url
+                    for trans in getattr(obj, "translations", []):
+                        trans_lang = getattr(trans, "lang", None)
+                        trans_url = clean_url(trans.url)
+                        if trans_lang and trans_url:
+                            translations[trans_lang] = get_full_url(siteurl, trans_url)
+                data["translations"] = translations
+
+        # Build URL map and group translations by slug
+        url_map = {}  # full_url -> {obj, slug, translations}
+        slug_translations = {}  # slug -> {lang: full_url}
+
+        for path, obj, lang, page_siteurl in self.page_queue:
+            add_to_url_map(url_map, slug_translations, path, obj, lang, page_siteurl)
+
+        link_translations(url_map, slug_translations)
+
+        def format_hreflang(translations):
+            if len(translations) <= 1:
+                return ""
+            lines = []
+            for lang, url in sorted(translations.items()):
+                lines.append(XML_TRANSLATION.format(lang, url))
+            return "\n".join(lines)
 
         with open(filename, "w", encoding="utf-8") as fd:
             if is_xml:
                 fd.write(XML_HEADER)
 
-            for pageurl, obj in page_queue:
+            for full_url in sorted(url_map.keys()):
+                data = url_map[full_url]
+                obj = data["obj"]
+
                 if not is_xml:
-                    fd.write(siteurl + "/" + pageurl + "\n")
-                    # That's it for txt. Short circuit the loop, gain an indent level.
+                    fd.write(full_url + "\n")
                     continue
 
                 lastmod = format_date(
@@ -165,42 +241,27 @@ class SitemapGenerator:
                 )
 
                 # see if changefreq specified in metadata headers; fall back to config
-                changefreq = getattr(obj, "changefreq", changefreqs[content_type])
+                changefreq = getattr(obj, "changefreq", changefreqs[content_type]) if obj else changefreqs[content_type]
                 if changefreq not in CHANGEFREQ_VALUES:
                     log.error(f"sitemap: Invalid 'changefreqs' value: {changefreq!r}")
                     changefreq = changefreqs[content_type]
 
                 # see if priority specified in metadata headers; fall back to config
-                priority_raw = getattr(obj, "priority", priorities[content_type])
+                priority_raw = getattr(obj, "priority", priorities[content_type]) if obj else priorities[content_type]
                 try:
                     priority = float(priority_raw)
                 except ValueError:
                     log.exception(
-                        "sitemap: Specify priority as a floating-point number, "
+                        f"sitemap: Specify priority as a floating-point number, "
                         f"not the current value: {priority_raw!r}"
                     )
                     priority = priorities[content_type]
 
-                # Use trans.url to respect custom URL settings for translations too
-                translations = "".join(
-                    XML_TRANSLATION.format(
-                        trans.lang,
-                        siteurl,
-                        clean_url(trans.url),
-                    )
-                    for trans in getattr(obj, "translations", ())
-                )
+                hreflang = format_hreflang(data["translations"])
 
-                fd.write(
-                    XML_URL.format(
-                        siteurl,
-                        pageurl,
-                        lastmod,
-                        changefreq,
-                        priority,
-                        translations=translations,
-                    )
-                )
+                fd.write(XML_URL.format(
+                    full_url, lastmod, changefreq, priority, hreflang
+                ))
 
             if is_xml:
                 fd.write(XML_FOOTER)

--- a/pelican/plugins/sitemap/test_data_i18n/article-en.md
+++ b/pelican/plugins/sitemap/test_data_i18n/article-en.md
@@ -1,0 +1,7 @@
+Title: Test Article
+Date: 2023-07-12 13:00:00
+Category: test
+Slug: test-article
+Lang: en
+
+This is an English article.

--- a/pelican/plugins/sitemap/test_data_i18n/article-es.md
+++ b/pelican/plugins/sitemap/test_data_i18n/article-es.md
@@ -1,0 +1,7 @@
+Title: Artículo de Prueba
+Date: 2023-07-12 13:00:00
+Category: test
+Slug: test-article
+Lang: es
+
+Este es un artículo en español.

--- a/pelican/plugins/sitemap/test_data_i18n/pages/about-en.md
+++ b/pelican/plugins/sitemap/test_data_i18n/pages/about-en.md
@@ -1,0 +1,5 @@
+Title: About
+Slug: about
+Lang: en
+
+About page in English.

--- a/pelican/plugins/sitemap/test_data_i18n/pages/about-es.md
+++ b/pelican/plugins/sitemap/test_data_i18n/pages/about-es.md
@@ -1,0 +1,5 @@
+Title: Acerca de
+Slug: about
+Lang: es
+
+Página acerca de en español.

--- a/pelican/plugins/sitemap/test_sitemap.py
+++ b/pelican/plugins/sitemap/test_sitemap.py
@@ -187,3 +187,134 @@ http://localhost/translated-post.html
         self.assertIn("http://localhost/pages/about-us/", contents)
         # Should NOT contain the filesystem path
         self.assertNotIn("http://localhost/p/about-us/", contents)
+
+
+class TestSitemapUrlNormalization(unittest.TestCase):
+    """Test URL normalization in sitemap (handles ../ from i18n_subsites)."""
+
+    def setUp(self):
+        self.output_path = mkdtemp(prefix="pelican-plugins-sitemap-norm-tests-")
+
+    def tearDown(self):
+        rmtree(self.output_path)
+
+    def test_translations_use_obj_url_not_relative(self):
+        """Test that translation URLs use obj.url (full path) not relative."""
+        settings = read_settings(
+            override={
+                "PATH": TEST_DATA,
+                "CACHE_CONTENT": False,
+                "SITEURL": "http://localhost",
+                "OUTPUT_PATH": self.output_path,
+                "PLUGINS": [sitemap],
+                "SITEMAP": {
+                    "format": "xml",
+                },
+            }
+        )
+        pelican = Pelican(settings=settings)
+        pelican.run()
+
+        with open(Path(self.output_path) / "sitemap.xml") as fd:
+            contents = fd.read()
+
+        # No relative path segments should appear in URLs
+        self.assertNotIn("/../", contents)
+        self.assertNotIn('href="../', contents)
+        # All hrefs should be absolute URLs
+        import re
+        hrefs = re.findall(r'href="([^"]+)"', contents)
+        for href in hrefs:
+            self.assertTrue(
+                href.startswith("http://") or href.startswith("https://"),
+                f"href should be absolute URL, got: {href}"
+            )
+
+    def test_all_locs_are_absolute_urls(self):
+        """Test that all <loc> entries are absolute URLs."""
+        settings = read_settings(
+            override={
+                "PATH": TEST_DATA,
+                "CACHE_CONTENT": False,
+                "SITEURL": "http://localhost",
+                "OUTPUT_PATH": self.output_path,
+                "PLUGINS": [sitemap],
+                "SITEMAP": {
+                    "format": "xml",
+                },
+            }
+        )
+        pelican = Pelican(settings=settings)
+        pelican.run()
+
+        with open(Path(self.output_path) / "sitemap.xml") as fd:
+            contents = fd.read()
+
+        import re
+        locs = re.findall(r'<loc>([^<]+)</loc>', contents)
+        for loc in locs:
+            self.assertTrue(
+                loc.startswith("http://") or loc.startswith("https://"),
+                f"<loc> should be absolute URL, got: {loc}"
+            )
+            self.assertNotIn("/../", loc, f"<loc> should not contain /../: {loc}")
+
+    def test_bidirectional_hreflang_links(self):
+        """Test that hreflang links are bidirectional (each URL links to all variants)."""
+        settings = read_settings(
+            override={
+                "PATH": TEST_DATA,
+                "CACHE_CONTENT": False,
+                "SITEURL": "http://localhost",
+                "OUTPUT_PATH": self.output_path,
+                "PLUGINS": [sitemap],
+                "SITEMAP": {
+                    "format": "xml",
+                },
+            }
+        )
+        pelican = Pelican(settings=settings)
+        pelican.run()
+
+        with open(Path(self.output_path) / "sitemap.xml") as fd:
+            contents = fd.read()
+
+        # For translated content, both en and fr should appear as hreflang
+        # Each translated URL entry should link to BOTH language variants
+        import re
+        url_blocks = re.findall(r'<url>(.*?)</url>', contents, re.DOTALL)
+
+        translated_blocks = [b for b in url_blocks if 'xhtml:link' in b]
+        for block in translated_blocks:
+            # Each translated entry should have links to both languages
+            self.assertIn('hreflang="en"', block)
+            self.assertIn('hreflang="fr"', block)
+
+    def test_no_duplicate_loc_entries(self):
+        """Test that each URL appears only once as <loc>."""
+        settings = read_settings(
+            override={
+                "PATH": TEST_DATA,
+                "CACHE_CONTENT": False,
+                "SITEURL": "http://localhost",
+                "OUTPUT_PATH": self.output_path,
+                "PLUGINS": [sitemap],
+                "SITEMAP": {
+                    "format": "xml",
+                },
+            }
+        )
+        pelican = Pelican(settings=settings)
+        pelican.run()
+
+        with open(Path(self.output_path) / "sitemap.xml") as fd:
+            contents = fd.read()
+
+        import re
+        locs = re.findall(r'<loc>([^<]+)</loc>', contents)
+        # Check for duplicates
+        seen = set()
+        for loc in locs:
+            self.assertNotIn(loc, seen, f"Duplicate <loc> found: {loc}")
+            seen.add(loc)
+


### PR DESCRIPTION
## Add i18n_subsites support for proper hreflang generation

### Problem

The sitemap plugin doesn't properly support the `i18n_subsites` Pelican plugin. When using `i18n_subsites`, each language runs as a separate Pelican instance with its own `SITEURL` (e.g., `https://example.com` for the main language and `https://example.com/en` for subsites). This caused several issues:

1. **Missing hreflang links**: Translations weren't linked because `i18n_subsites` doesn't populate `obj.translations` - each language version is processed independently
2. **Incorrect URLs**: The sitemap used relative URLs that didn't account for the different `SITEURL` per language
3. **Malformed paths**: Translation URLs from Pelican's native mechanism contained `../` segments that weren't normalized

### Solution

This PR adds proper i18n_subsites support by:

1. **Tracking language context per page**: Store `SITEURL` and `DEFAULT_LANG` from each page's context during `queue_page()`, preserving the language-specific settings from each i18n_subsites run

2. **Slug-based translation grouping**: Group articles/pages by their slug across all languages. Since the same content in different languages shares the same slug, this correctly links translations even when `i18n_subsites` processes them separately

3. **Full URL generation**: Build absolute URLs using each page's own `SITEURL`, with proper normalization of `../` path segments using `posixpath.normpath`

4. **Dual translation mechanism**: Support both:
   - Slug-based grouping (for `i18n_subsites`)
   - Pelican's native `obj.translations` (for standard multi-language setups)

### Changes

- Updated `XML_URL` and `XML_TRANSLATION` templates to use full URLs
- Added `get_full_url()` helper with URL path normalization
- Added `add_to_url_map()` to build URL map with slug tracking
- Added `link_translations()` to merge translations from both mechanisms
- Added `format_hreflang()` to generate hreflang XML links
- Track `current_lang` and `current_siteurl` per queued page

### Example output

Before (missing hreflang):
```xml
<url>
<loc>https://example.com/en/about/</loc>
</url>
```

After (proper bidirectional hreflang):
```xml
<url>
<loc>https://example.com/en/about/</loc>
<xhtml:link rel="alternate" hreflang="en" href="https://example.com/en/about/"/>
<xhtml:link rel="alternate" hreflang="es" href="https://example.com/about/"/>
</url>
```