### PR TITLE
Fix duplicate sitemap entries caused by `pelican-redirect` plugin

### DIFF
--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -139,6 +139,11 @@ class SitemapGenerator:
             for path, obj in self.page_queue
         ]
         page_queue = [page for page in page_queue if not is_excluded(page)]
+
+        # Remove duplicate entries which might be caused by pelican-redirect plugin
+        page_queue = list(set(page_queue))
+
+        # Sorting the pages after removing duplicates guarantees the correct order
         page_queue.sort(key=lambda i: i[0])
 
         with open(filename, "w", encoding="utf-8") as fd:


### PR DESCRIPTION
fixes https://github.com/pelican-plugins/sitemap/issues/50

I did not add any additional unit tests because the ones in place should cover this little change.