### PR TITLE
Fix for outdated/broken sitemap tags

### DIFF
--- a/pelican/plugins/sitemap/sitemap.py
+++ b/pelican/plugins/sitemap/sitemap.py
@@ -11,10 +11,7 @@ from pelican import contents, signals
 log = logging.getLogger(__name__)
 
 XML_HEADER = """<?xml version="1.0" encoding="utf-8"?>
-<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
-xmlns:xhtml="http://www.w3.org/1999/xhtml"
-xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 """
 
 TXT_URL = "{0}/{1}\n"
@@ -37,13 +34,8 @@ XML_FOOTER = """
 
 
 def format_date(date):
-    """Format the date in the expected format."""
-    if date.tzinfo:
-        tz = date.strftime("%z")
-        tz = tz[:-2] + ":" + tz[-2:]
-    else:
-        tz = "-00:00"
-    return date.strftime("%Y-%m-%dT%H:%M:%S") + tz
+    """Format the date in the expected format. See: https://www.sitemaps.org/protocol.html."""
+    return date.strftime("%Y-%m-%d")
 
 
 CHANGEFREQ_DEFAULTS = {


### PR DESCRIPTION
- urlset tag is outdated - fixed
- lastmod tags are not formatted correctly (see https://www.sitemaps.org/protocol.html) - fixed

I've created a temporary script for immediate fixes to the problems: https://gist.github.com/bhagman/57f406f6c75b761bb9441cf204feeb73